### PR TITLE
fixing unordered files

### DIFF
--- a/lib/bdd_rails/templates/install/spec/spec_helper.rb
+++ b/lib/bdd_rails/templates/install/spec/spec_helper.rb
@@ -7,6 +7,6 @@
 #
 # For more information head to https://github.com/lukemorton/bdd-rails
 #
-Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each do |support_file|
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].sort.each do |support_file|
   require support_file
 end


### PR DESCRIPTION
When running tests on codeship (and possibly other unix boxes) the order of files isn't guaranteed.

Fixed with a sort before the each.
